### PR TITLE
Check empty value when dispatch

### DIFF
--- a/mysql.py
+++ b/mysql.py
@@ -455,8 +455,10 @@ def dispatch_value(prefix, key, value, type, type_instance=None):
 	if not type_instance:
 		type_instance = key
 
-	value = int(value) # safety check
 	log_verbose('Sending value: %s/%s=%s' % (prefix, type_instance, value))
+	if not value:
+		return
+	value = int(value) # safety check
 
 	val               = collectd.Values(plugin='mysql', plugin_instance=prefix)
 	val.type          = type


### PR DESCRIPTION
If value in list is empty, plugin crashed with error ValueError: invalid literal for int() with base 10: ''