### PR TITLE
Change into to float as the value can be '0.00'

### DIFF
--- a/mysql.py
+++ b/mysql.py
@@ -272,7 +272,7 @@ MYSQL_INNODB_STATUS_MATCHES = {
 	# --Thread 139954487744256 has waited at dict0dict.cc line 472 for 0.0000 seconds the semaphore:
 	'seconds the semaphore': {
 		'innodb_sem_waits': lambda row, stats: stats['innodb_sem_waits'] + 1,
-		'innodb_sem_wait_time_ms': lambda row, stats: int(row[9]) * 1000,
+		'innodb_sem_wait_time_ms': lambda row, stats: float(row[9]) * 1000,
 	},
 	# mysql tables in use 1, locked 1
 	'mysql tables in use': {


### PR DESCRIPTION
Currently will throw an error when trying to parse the 'innodb_sem_wait_time_ms' as it is a float not int.