### PR TITLE
add config for defaults file option, allow for multiple instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,28 @@ You should then configure the MySQL plugin:
 			HeartbeatTable "percona.heartbeat" (if using pt-heartbeat to track slave lag)
 			Verbose false (default: false)
 		</Module>
-	</Python>
+	</Plugin>
+
+You can use a defaults file instead of the user and password, which will also allow
+use of a nonstandard socket location.   Then you can collect separate stats for
+multiple MySQL instances:
+
+	<Plugin python>
+		Import mysql
+		<Module mysql>
+			Host "localhost"
+			Port 3306
+			DefaultsFile "/root/.my.cnf-foo"
+			Instance "foo"
+		</Module>
+		<Module mysql>
+			Host "localhost"
+			Port 3306
+			DefaultsFile "/root/.my.cnf-bar"
+			Instance "bar"
+		</Module>
+	</Plugin>
+
 
 ## Metrics
 

--- a/mysql.py
+++ b/mysql.py
@@ -34,6 +34,8 @@ MYSQL_CONFIG = {
 	'Password':       '',
 	'HeartbeatTable': '',
 	'Verbose':        False,
+	'DefaultsFile':   '',
+	'Instance':       ''
 }
 
 MYSQL_STATUS_VARS = {
@@ -285,12 +287,20 @@ MYSQL_INNODB_STATUS_MATCHES = {
 }
 
 def get_mysql_conn():
-	return MySQLdb.connect(
-		host=MYSQL_CONFIG['Host'],
-		port=MYSQL_CONFIG['Port'],
-		user=MYSQL_CONFIG['User'],
-		passwd=MYSQL_CONFIG['Password']
-	)
+    # if defaults file is set, use it vice user and password
+	if MYSQL_CONFIG['DefaultsFile']:
+		return MySQLdb.connect(
+			host=MYSQL_CONFIG['Host'],
+			port=MYSQL_CONFIG['Port'],
+			read_default_file=MYSQL_CONFIG['DefaultsFile']
+		)
+	else:
+		return MySQLdb.connect(
+			host=MYSQL_CONFIG['Host'],
+			port=MYSQL_CONFIG['Port'],
+			user=MYSQL_CONFIG['User'],
+			passwd=MYSQL_CONFIG['Password']
+		)
 
 def mysql_query(conn, query):
 	cur = conn.cursor(MySQLdb.cursors.DictCursor)
@@ -455,6 +465,9 @@ def log_verbose(msg):
 def dispatch_value(prefix, key, value, type, type_instance=None):
 	if not type_instance:
 		type_instance = key
+
+	if MYSQL_CONFIG['Instance']:
+		prefix = prefix + '/' + MYSQL_CONFIG['Instance']
 
 	log_verbose('Sending value: %s/%s=%s' % (prefix, type_instance, value))
 	if not value:


### PR DESCRIPTION
At my job we use multiple instances per mysql server, with each in a nonstandard location.

These changes support configuration of a defaults file location and an instance name.  The defaults file can contain the mysql socket location, and then multiple instances can be configured via different defaults files and instance names.   

If the defaults file is configured, it must contain the username and password.