### PR TITLE
Correct collectd python exception

### DIFF
--- a/mysql.py
+++ b/mysql.py
@@ -272,7 +272,7 @@ MYSQL_INNODB_STATUS_MATCHES = {
 	# --Thread 139954487744256 has waited at dict0dict.cc line 472 for 0.0000 seconds the semaphore:
 	'seconds the semaphore': {
 		'innodb_sem_waits': lambda row, stats: stats['innodb_sem_waits'] + 1,
-		'innodb_sem_wait_time_ms': lambda row, stats: int(row[9]) * 1000,
+		'innodb_sem_wait_time_ms': lambda row, stats: float(row[9]) * 1000,
 	},
 	# mysql tables in use 1, locked 1
 	'mysql tables in use': {


### PR DESCRIPTION
Collectd python plugin was throwing exception from time to time:
Unhandled python exception in read callback: ValueError: invalid literal for int() with base 10: '0.0000'
This disables plugin for 120 seconds. 
Changing int to float at line 275 corrects the problem