### PR TITLE
Fix fetch_innodb_stats runtime error (#11)

### DIFF
--- a/mysql.py
+++ b/mysql.py
@@ -477,7 +477,8 @@ def fetch_innodb_stats(conn):
 				for key in MYSQL_INNODB_STATUS_MATCHES[match]:
 					value = MYSQL_INNODB_STATUS_MATCHES[match][key]
 					if type(value) is int:
-						stats[key] = int(row[value])
+						if value < len(row) and row[value].isdigit():
+							stats[key] = int(row[value])
 					else:
 						stats[key] = value(row, stats)
 				break


### PR DESCRIPTION
This closes chrisboulton/collectd-python-mysql#11

Sometimes, mysql server returns slightly "malformed" strings with stats.
For example:

```
 ibuf aio reads:, log i/o's:, sync i/o's:
```

instead of:

```
 ibuf aio reads: 0, log i/o's: 0, sync i/o's: 0
```

In that case fetch_innodb_stats() will fail with error `ValueError: invalid literal for int() with base 10: 'log'`
