### PR TITLE
Verify lowercase keys are set

### DIFF
--- a/mysql.py
+++ b/mysql.py
@@ -437,6 +437,8 @@ def fetch_mysql_response_times(conn):
 		if not row:
 			row = { 'count': 0, 'total': 0 }
 
+		row = {key.lower(): val for key, val in row.items()}
+
 		response_times[i] = {
 			'time':  float(row['time']),
 			'count': int(row['count']),


### PR DESCRIPTION
In MySQL 5.7, the keys returned from QUERY_RESPONSE_TIME are in all
caps.  This verifies that lower case versions of these keys are always
set.

```
(Pdb) row.keys()
['COUNT', 'TOTAL', 'TIME']
```