### PR TITLE
Add Docker development workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM pataquets/collectd-python-pip
+
+RUN \
+  apt-get update && \
+  DEBIAN_FRONTEND=noninteractive \
+    apt-get -y install libmysqlclient-dev \
+  && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache mysqlclient
+
+RUN \
+  ln -vs /etc/collectd/conf-available/write-csv-stdout.conf \
+    /etc/collectd/conf.d/ \
+  && \
+  nl \
+    /etc/collectd/collectd.conf \
+    /etc/collectd/conf.d/*

--- a/README.md
+++ b/README.md
@@ -322,5 +322,8 @@ For versions of MySQL with support for it and where enabled, `INFORMATION_SCHEMA
     response_time_total.14
     response_time_count.14
 
+## Development
+A Docker Compose manifest with a stack for testing and development is provided. Just issue ```docker-compose up --build``` to start it. See ```docker-compose.yml``` and ```mysql.conf``` files for configuration details.
+
 ## License
 MIT (http://www.opensource.org/licenses/mit-license.php)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+# Docker Compose development manifest
+# This manifest spins up a MariaDB/MySQL server container and builds a
+# collectd+python image with all required runtime dependencies and starts
+# a collectd container linked to the database container to allow testing.
+
+# By default, MariaDB/MySQL port is not exposed to the development host,
+# since collectd connects using a hostname defined via container link.
+mysql:
+  image: mariadb
+  environment:
+    - MYSQL_ALLOW_EMPTY_PASSWORD=yes
+#    - MYSQL_ROOT_PASSWORD=root
+#    - MYSQL_USER=collectd
+#    - MYSQL_PASSWORD=collectd
+#  ports:
+#    - "3306:3306"
+
+# Collectd service mounts both Python code and plugin configuration from
+# current development directory.
+# The parent image used for the build just uses collectd's built in CSV
+# plugin with output to stdout for debugging.
+collectd:
+  build: .
+  links:
+    - mysql
+  volumes:
+    - ./mysql.py:/opt/collectd/lib/collectd/plugins/python/mysql.py:ro
+    - ./mysql.conf:/etc/collectd/conf.d/mysql.conf:ro

--- a/mysql.conf
+++ b/mysql.conf
@@ -1,0 +1,18 @@
+<LoadPlugin python>
+  Globals true
+</LoadPlugin>
+<Plugin python>
+  ModulePath "/opt/collectd/lib/collectd/plugins/python/"
+  # Verbose true
+</Plugin>
+<Plugin python>
+  Import mysql
+  <Module mysql>
+    Host "mysql"
+    # Port 3306
+    # User "root" # (default: root)
+    # Password "xxxx" # (default: empty)
+    # HeartbeatTable "percona.heartbeat" # (if using pt-heartbeat to track slave lag)
+    # Verbose false # (default: false)
+  </Module>
+</Plugin>


### PR DESCRIPTION
Add Docker workflow for making easier to start hacking. No devel packages nor development libs installation needed on development host, just Docker and Docker Compose and you're ready to go. People familiar with Docker will figure out themselves
Run:
```
$ docker-compose up --build
```
Stop by ```CTRL+C```'ing.

Manifest launches a MariaDB server container based on ```mariadb[:latest]``` image and a collectd+python runtime container built from my ```pataquets/collectd-python-pip``` base image which just adds the necessary configs to send all collectd readings to stdout using the CSV plugin (see Dockerfile). Both containers are linked to allow collectd to connect to db via the ```mysql``` hostname.
The collectd container mounts from the Docker host's git repo directory:
* The Python program file.
* The ```mysql.conf``` config file.

Just hack, change confs and test by ```CTRL+C``` and ```up```'ing again. Rinse and repeat.

This is what I've used so far to start tinkering and getting warm to tackle opened issues, some opened by me (#25, #27, #28). Hopefully, it will also help others interested in them to jump in and get up to speed quickly. HTH.