### PR TITLE
Unhandled python exception in read callback: KeyError: 'Innodb_purge_trx_id'

### DIFF
--- a/mysql.py
+++ b/mysql.py
@@ -349,7 +349,7 @@ def fetch_mysql_status(conn):
 		status[row['Variable_name']] = row['Value']
 
 	# calculate the number of unpurged txns from existing variables
-	if 'Innodb_max_trx_id' in status:
+	if 'Innodb_max_trx_id' in status and 'Innodb_purge_trx_id' in status:
 		status['Innodb_unpurged_txns'] = int(status['Innodb_max_trx_id']) - int(status['Innodb_purge_trx_id'])
 
 	if 'Innodb_lsn_last_checkpoint' in status:


### PR DESCRIPTION
Mariadb 10.5 (possibly all version since 10.3.23 ?) expose 'Innodb_max_trx_id' without 'Innodb_purge_trx_id' resulting in "Unhandled python exception in read callback: KeyError: 'Innodb_purge_trx_id'"